### PR TITLE
change privacy provider implementation sinci this is not really a nul…

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -21,16 +21,11 @@
  * @copyright  2019 Sergio Comerón Sánchez-Paniagua <sergiocomeron@icloud.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class provider implements \core_privacy\local\metadata\null_provider {
-    /**
-     * Get the language string identifier with the component's language
-     * file to explain why this plugin stores no data.
-     *
-     * @return  string
-     */
-    public static function get_reason() : string {
-        return 'privacy:metadata';
-    }
+namespace mod_jitsi\privacy;
+
+use core_privacy\local\metadata\collection;
+
+class provider implements \core_privacy\local\metadata\provider {
 
     public static function get_metadata(collection $collection) : collection {
 


### PR DESCRIPTION
Hello,
In order to pass unit tests (vendor/bin/phpunit "provider_testcase" privacy/tests/provider_test.php
), I made a correction on your privacy class implementation.
You forgot namespace for your class
Indeed, your class  must not implement null_provider since you have an external link
So i changed the implemented class


Looking forward to using your plugin very soon
Sincerely
Céline Pervès